### PR TITLE
Replace fontawesome and animate.css, few perf and style changes

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Chop it!</title>
 
     <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png">
@@ -8,16 +10,17 @@
     <link rel="icon" href="/favicon-62.png" sizes="62x62" type="image/png">
     <link rel="icon" href="/favicon-192.png" sizes="192x192" type="image/png">
 
-    <!-- FontAwesome -->
-    <script async src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
-
     <!-- Miligram CSS -->
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="//cdn.rawgit.com/necolas/normalize.css/master/normalize.css">
-    <link rel="stylesheet" href="//cdn.rawgit.com/milligram/milligram/master/dist/milligram.min.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Slab">
+    <link rel="stylesheet" href="https://cdn.rawgit.com/necolas/normalize.css/master/normalize.css">
+    <link rel="stylesheet" href="https://cdn.rawgit.com/milligram/milligram/master/dist/milligram.min.css">
 
     <!-- Animate.css -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css">
+
+    <!-- Chop it -->
+    <link rel="stylesheet" type="text/css" href="/styles.css"/>
+    <script src="/scripts.js" type="text/javascript"></script>
 
   </head>
 
@@ -26,16 +29,16 @@
       <h1>Chop My Url</h1>
       <h6>Shortener URL based on <a href="https://now.sh">Now 2</a></h6>
       <fieldset>
-        <input type="text" placeholder="..." id="input" style="background-color: white;">
-        <button class="button button-cover" onclick="send()">Chop!</button>
+        <input type="text" placeholder="..." id="input">
+        <button class="button button-cover" id="chop-it">Chop!</button>
       </fieldset>
       <fieldset class="overflow-allowed">
-        <button class="button button-clear button-cover" id="output" onclick="copy()"></button>
+        <button class="button button-clear button-cover hidden" id="output">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4H8c-1.1 0-1.99.9-1.99 2L6 21c0 1.1.89 2 1.99 2H19c1.1 0 2-.9 2-2V11l-6-6zM8 21V7h6v5h5v9H8z"/></svg>
+          <span id="output-url"></span>
+        </button>
       </fieldset>
     </div>
   </body>
-
-  <link rel="stylesheet" type="text/css" href="/styles.css"/>
-  <script src="/scripts.js" type="text/javascript"></script>
 
 </html>

--- a/front/scripts.js
+++ b/front/scripts.js
@@ -37,8 +37,9 @@ const send = async () => {
 const updateCopyField = () => {
   // if the variable exists and is different from undefined.
   if (LATEST_SHORT) {
-    const target = document.getElementById('output')
-    target.innerHTML = `<i class="far fa-copy"></i> ${LATEST_SHORT}`
+    const target = document.getElementById('output-url')
+    document.getElementById('output').classList.remove('hidden')
+    target.innerText = LATEST_SHORT
   }
 }
 
@@ -64,3 +65,13 @@ const copy = async () => {
     await navigator.clipboard.writeText(LATEST_SHORT)
   }
 }
+
+
+/**
+ * attach events on load
+ */
+window.addEventListener('load', () => {
+  // add events
+  document.getElementById('chop-it').addEventListener('click', send)
+  document.getElementById('output').addEventListener('click', copy)
+})

--- a/front/styles.css
+++ b/front/styles.css
@@ -16,10 +16,30 @@ body {
   line-height: 4.5rem;
   padding: 0 2rem;
   width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 h1, h6 {
   text-align: center;
+}
+
+.hidden {
+  display: none;
+}
+
+#input {
+  background-color: white;
+}
+
+#output svg {
+  width: 1.5rem;
+  margin: 0 0.2rem;
+}
+
+#output svg path {
+  fill: currentColor;
 }
 
 /* Larger than mobile screen */
@@ -35,4 +55,44 @@ h1, h6 {
 /* Larger than desktop screen */
 @media (min-width: 120.0rem) {
 
+}
+
+/* https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.css */
+.animated {
+  animation-duration: 1s;
+  animation-fill-mode: both;
+}
+
+@keyframes rubberBand {
+  from {
+    transform: scale3d(1, 1, 1);
+  }
+
+  30% {
+    transform: scale3d(1.25, 0.75, 1);
+  }
+
+  40% {
+    transform: scale3d(0.75, 1.25, 1);
+  }
+
+  50% {
+    transform: scale3d(1.15, 0.85, 1);
+  }
+
+  65% {
+    transform: scale3d(0.95, 1.05, 1);
+  }
+
+  75% {
+    transform: scale3d(1.05, 0.95, 1);
+  }
+
+  to {
+    transform: scale3d(1, 1, 1);
+  }
+}
+
+.rubberBand {
+  animation-name: rubberBand;
 }


### PR DESCRIPTION
1. Apparently font-awesome is used only for `fa-copy` icon. This loads 401KB of JS for just a single icon. Replaced with material icon inlined SVG
2. `animate.css` has a load of classes, the required classes are inlined into `style.css` which is one less http connection. Removed vendor prefixes `-webkit-`
3. Current font loaded is `Roboto` in 300 and 700 regular and italic weights, but the default font set is `Roboto Slab`. This doesn't even bother to load the font files(`woff`). (Assuming `Roboto Slab` is the one required) replaced the URL with the one pointing to `Roboto Slab`.
4. Replaced inline JS event handling to event listeners in `scripts.js`

After changes the site weighs in at 30.7KB (including fonts, previously not included - 404KB)